### PR TITLE
Refactor import statements to use absolute imports in cli.py and docs…

### DIFF
--- a/pydocgen/cli.py
+++ b/pydocgen/cli.py
@@ -9,9 +9,9 @@ from typing import Optional
 import click
 import yaml
 
-from .config import Config
-from .docstring_generator import DocstringGenerator
-from .git_utils import get_modified_python_files
+from config import Config
+from docstring_generator import DocstringGenerator
+from git_utils import get_modified_python_files
 
 PASS = 0
 FAIL = 1
@@ -79,6 +79,8 @@ def main(style, verbosity, config, exclude, include_private, filenames) -> int:
     Process Python files to add or update docstrings based on code analysis.
     If FILENAMES are not provided, will use git to find modified files.
     """
+    sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+    
     # Load configuration
     config_dict = load_config(config)
     

--- a/pydocgen/docstring_generator.py
+++ b/pydocgen/docstring_generator.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import astroid
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
-from .config import Config
+from config import Config
 
 
 class DocstringGenerator:

--- a/pydocgen/git_utils.py
+++ b/pydocgen/git_utils.py
@@ -13,17 +13,12 @@ def get_modified_python_files() -> List[Path]:
     """
     try:
         # Get staged files
-        staged_cmd = ["git", "diff", "--cached", "--name-only", "--diff-filter=ACMR"]
+        staged_cmd = ["git", "diff", "--cached", "--name-only"]
         staged_output = subprocess.check_output(staged_cmd, universal_newlines=True)
         staged_files = staged_output.splitlines()
         
-        # Get unstaged files
-        unstaged_cmd = ["git", "diff", "--name-only", "--diff-filter=ACMR"]
-        unstaged_output = subprocess.check_output(unstaged_cmd, universal_newlines=True)
-        unstaged_files = unstaged_output.splitlines()
-        
         # Combine and filter for Python files
-        all_files = set(staged_files + unstaged_files)
+        all_files = set(staged_files)
         python_files = [Path(f) for f in all_files if f.endswith(".py")]
         
         return python_files

--- a/uv.lock
+++ b/uv.lock
@@ -128,7 +128,7 @@ wheels = [
 ]
 
 [[package]]
-name = "pydocgen-hook"
+name = "pydocgen"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [


### PR DESCRIPTION
…tring_generator.py; update git_utils.py to only retrieve staged Python files; rename package in uv.lock from "pydocgen-hook" to "pydocgen"